### PR TITLE
Makefile: add a way to exclude specific files with EXCLUDE

### DIFF
--- a/build/device-common.mk
+++ b/build/device-common.mk
@@ -68,6 +68,9 @@ endif
 
 # List of the objects files to be compiled/assembled based on source files in SRC.
 OBJECTS := $(call srcs2objs,$(call filter_dirs,$(call recurse_dir,$(SRC)),$(TARGETS_FOR_DEVICE)),$(SRC),$(OUTDIR))
+PAT_MATCH = $(foreach v,$(2),$(if $(findstring $(1),$(v)),$(v),))
+EXCL_OBJECTS := $(foreach e,$(EXCLUDE),$(call PAT_MATCH,$(e),$(OBJECTS)))
+OBJECTS := $(filter-out $(EXCL_OBJECTS),$(OBJECTS))
 
 # Add in the GCC4MBED stubs which allow hooking in the MRI debug monitor.
 OBJECTS += $(OUTDIR)/gcc4mbed.o

--- a/build/gcc4mbed.mk
+++ b/build/gcc4mbed.mk
@@ -23,7 +23,7 @@
 #                 of the build directory which contains this gcc4mbed.mk file.
 #
 # Variables that may be optionally set in makefile.
-#   DEVCICES: Used to specify a space delimited list of target device(s) that
+#   DEVICES: Used to specify a space delimited list of target device(s) that
 #             this application should be built for.  Allowed values include:
 #              LPC1768
 #              LPC11U24
@@ -31,6 +31,7 @@
 #              NRF51822
 #              default: LPC1768
 #   SRC: The root directory for the sources of your project.  Defaults to '.'.
+#   EXCLUDE: Patterns of file to exclude from the root directory of sources 
 #   NO_FLOAT_SCANF: When set to 1, scanf() will not support %f specifier to
 #                   input floating point values.  Reduces code size.
 #   NO_FLOAT_PRINTF: When set to 1, scanf() will not support %f specifier to

--- a/notes/makefile.creole
+++ b/notes/makefile.creole
@@ -46,6 +46,9 @@ The default target device is LPC1768.
 ===SRC
 The **SRC** variable is used in an application's makefile to specify the root directory of the sources for this project.  If not explicitly set by the application's makefile then it defaults to the directory in which the makefile is located.  However it can be set to a different directory name if it happens that the project's source code is found in a different directory than the makefile.
 
+===EXCLUDE
+The **EXCLUDE** variable is used in an application's makefile to specify a pattern to exclude files from **SRC** variable. This allows more flexible build without having to move directories to avoid building them. This variable is a space-separated list of patterns to exclude from build.
+
 ===MBED_LIBS
 The **MBED_LIBS** variable is an optional variable that an application's makefile can use to provide a space delimited list of additional official mbed libraries to be used.  The order of the libraries in this list will matter since they dictate link order.  The supported libraries include:
 * **net/eth**: Pulls in the ethernet version of the TCP/IP networking stack and its dependencies (ie. rtos).


### PR DESCRIPTION
This patch add a special make variable named EXCLUDE to allow exclusion of specific files from the final object.
It allows to make conditionnal builds much simpler.