### PR TITLE
Makefile: remove trailing slash if provided by user

### DIFF
--- a/build/gcc4mbed.mk
+++ b/build/gcc4mbed.mk
@@ -112,6 +112,7 @@ ifndef GCC4MBED_DIR
 $(error makefile must set GCC4MBED_DIR.)
 endif
 
+GCC4MBED_DIR := $(patsubst %/,%,$(GCC4MBED_DIR))
 
 # Set VERBOSE make variable to 1 to output all tool commands.
 VERBOSE?=0


### PR DESCRIPTION
When a trailing slash is given to GCC4MBED_DIR, it seems that some gcc4mbed implicit rules are no more matching and GNU Make fall back on default rules using gcc without any flags.
This bug can be easily reproduced by setting GCC4MBED_DIR := ../../ in USBMouse sample makefile for instance.
This patch remove the trailing slash from GCC4MBED_DIR var if any.