### PR TITLE
Fixed name of linker script for STM32F407VG

### DIFF
--- a/build/DISCO_F407VG-device.mk
+++ b/build/DISCO_F407VG-device.mk
@@ -37,7 +37,7 @@ DEVICE_MRI_LIB :=
 
 
 # Linker script to be used.  Indicates what code should be placed where in memory.
-LSCRIPT=$(GCC4MBED_DIR)/external/mbed/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_STM32F407VG/TOOLCHAIN_GCC_ARM/STM32F407.ld
+LSCRIPT=$(GCC4MBED_DIR)/external/mbed/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_STM32F407VG/TOOLCHAIN_GCC_ARM/STM32F407XG.ld
 
 
 include $(GCC4MBED_DIR)/build/device-common.mk


### PR DESCRIPTION
Changed to match mbed library linker name. 


Thanks for this library! I've been struggling to get mbed going on the stm32f4 and mbed v3.0 with proper tools & guides looks like it's a while away.