### PR TITLE
Added more specific detail in the instructions

### DIFF
--- a/notes/porting.creole
+++ b/notes/porting.creole
@@ -1,10 +1,17 @@
 ==Downloading Projects from Cloud
 The original source of these steps for downloading an existing project from the cloud compiler were posted to the mbed forum by Peter Drescher in [[http://developer.mbed.org/forum/mbed/topic/2701/?page=2#comment-14008|this post]].
 
-* Export the code on the cloud compiler and unpack into a new directory in the sample folder.
-* If you use an imported lib, open the .lib file. It will contain a link to get the library code.  Download the lib and unpack also.
-* Copy the makefile from the StdIO sample.
-* Change the project name inside the makefile.
-* Start BuildShell.
-* Go inside the project directory.
-* make clean all
+* Export the code on the cloud compiler
+ ** In the Program Workspace, [right-]click the project of interest (e.g. "mbed_blinky")
+ ** Choose "Export Program..." 
+ ** Select "GCC (ARM Embedded)", or perhaps "Zip Archive (with repositories)"
+ ** Unpack the project (e.g. "mbed_blinky") as a new directory in the "samples" folder.
+* If you use an imported lib,
+ ** Open the .lib file in an editor. It will contain a link to get the library code. 
+ ** Download the lib and unpack it as a directory along side where the .lib file is.
+* Copy the makefile from the StdIO sample into the top-directory of your project (e.g. "mbed_blinky"), replacing the Makefile that is there.
+* Edit the makefile:
+ ** Change the project name inside the makefile. (e.g. "PROJECT    := StdIO" => "PROJECT    := mbed_blinky")
+* Start BuildShell (e.g. double-click on BuildShell.cmd)
+* Go inside the project directory (e.g. "cd mbed_blinky")
+* Initial the Build (e.g. "make clean all")


### PR DESCRIPTION
The next to final instruction should have shown in the example (e.g. "cd samples\mbed_blinky").