### PR TITLE
Add support for F446 boards

### DIFF
--- a/build/B96B_F446VE-device.mk
+++ b/build/B96B_F446VE-device.mk
@@ -1,0 +1,43 @@
+# Copyright 2016 garyservin (https://github.com/garyservin)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Vendor/device for which the library should be built.
+MBED_DEVICE        := B96B_F446VE
+MBED_CLEAN         := $(MBED_DEVICE)-MBED-clean
+
+
+# Compiler flags which are specifc to this device.
+TARGETS_FOR_DEVICE := TARGET_B96B_F446VE TARGET_M4 TARGET_RTOS_M4_M7 TARGET_CORTEX_M TARGET_STM TARGET_STM32F4
+TARGETS_FOR_DEVICE += TARGET_STM32F446VE TARGET_FF_ARDUINO
+GCC_DEFINES := $(patsubst %,-D%,$(TARGETS_FOR_DEVICE))
+GCC_DEFINES += -D__CORTEX_M4 -DARM_MATH_CM4 -D__FPU_PRESENT=1
+
+C_FLAGS   := -mcpu=cortex-m4 -mthumb -mfpu=fpv4-sp-d16 -mfloat-abi=softfp -mthumb-interwork
+ASM_FLAGS := -mcpu=cortex-m4 -mthumb -mfpu=fpv4-sp-d16 -mfloat-abi=softfp
+LD_FLAGS  := -mcpu=cortex-m4 -mthumb -mfpu=fpv4-sp-d16 -mfloat-abi=softfp
+
+
+# Extra platform specific object files to link into file binary.
+DEVICE_OBJECTS :=
+
+
+# Version of MRI library to use for this device.
+DEVICE_MRI_LIB :=
+
+
+# Linker script to be used.  Indicates what code should be placed where in memory.
+B96B_F446VE_LSCRIPT ?= $(GCC4MBED_DIR)/external/mbed/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_B96B_F446VE/TOOLCHAIN_GCC_ARM/STM32F446XE.ld
+LSCRIPT = $(B96B_F446VE_LSCRIPT)
+
+include $(GCC4MBED_DIR)/build/device-common.mk

--- a/build/NUCLEO_F446RE-device.mk
+++ b/build/NUCLEO_F446RE-device.mk
@@ -1,0 +1,44 @@
+# Copyright 2016 garyservin (https://github.com/garyservin)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Vendor/device for which the library should be built.
+MBED_DEVICE        := NUCLEO_F446RE
+MBED_CLEAN         := $(MBED_DEVICE)-MBED-clean
+
+
+# Compiler flags which are specifc to this device.
+TARGETS_FOR_DEVICE := TARGET_NUCLEO_F446RE TARGET_M4 TARGET_RTOS_M4_M7 TARGET_CORTEX_M TARGET_STM TARGET_STM32F4
+TARGETS_FOR_DEVICE += TARGET_STM32F446RE TARGET_FF_ARDUINO TARGET_FF_MORPHO
+GCC_DEFINES := $(patsubst %,-D%,$(TARGETS_FOR_DEVICE))
+GCC_DEFINES += -D__CORTEX_M4 -DARM_MATH_CM4 -D__FPU_PRESENT=1
+
+C_FLAGS   := -mcpu=cortex-m4 -mthumb -mfpu=fpv4-sp-d16 -mfloat-abi=softfp -mthumb-interwork
+ASM_FLAGS := -mcpu=cortex-m4 -mthumb -mfpu=fpv4-sp-d16 -mfloat-abi=softfp
+LD_FLAGS  := -mcpu=cortex-m4 -mthumb -mfpu=fpv4-sp-d16 -mfloat-abi=softfp
+
+
+# Extra platform specific object files to link into file binary.
+DEVICE_OBJECTS :=
+
+
+# Version of MRI library to use for this device.
+DEVICE_MRI_LIB :=
+
+
+# Linker script to be used.  Indicates what code should be placed where in memory.
+NUCLEO_F446RE_LSCRIPT ?= $(GCC4MBED_DIR)/external/mbed/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F446RE/TOOLCHAIN_GCC_ARM/STM32F446XE.ld
+LSCRIPT = $(NUCLEO_F446RE_LSCRIPT)
+
+
+include $(GCC4MBED_DIR)/build/device-common.mk

--- a/samples/HelloWorld/makefile
+++ b/samples/HelloWorld/makefile
@@ -22,6 +22,8 @@ DEVICES         := DISCO_F407VG \
                    NRF51822 \
                    NUCLEO_F401RE \
                    NUCLEO_F411RE \
+                   NUCLEO_F446RE \
+                   B96B_F446VE \
                    NUCLEO_F072RB \
                    NUCLEO_F103RB \
                    NUCLEO_L053R8

--- a/samples/rtos_basic/makefile
+++ b/samples/rtos_basic/makefile
@@ -20,6 +20,8 @@ DEVICES         := DISCO_F407VG \
                    LPC4330_M4 \
                    NUCLEO_F401RE \
                    NUCLEO_F411RE \
+                   NUCLEO_F446RE \
+                   B96B_F446VE \
                    NUCLEO_F072RB \
                    NUCLEO_F103RB
 GCC4MBED_DIR    := ../..


### PR DESCRIPTION
Added support for both the NUCLEO_F446RE and the B96B_F446VE, I've tested both the HelloWorld and the rtos-basic examples on both boards and they seemed to work fine.